### PR TITLE
Prevent console warnings 

### DIFF
--- a/gsearch.py
+++ b/gsearch.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 class GoogleImageSearchExtention(GObject.GObject , Nautilus.MenuProvider):
     def __init__(self):
+        GObject.GObject.__init__(self)
         logger.debug=("Initializing Image Search extention...")
         self.SERVICE_MAPPING = {
             "Google": {

--- a/gsearch.py
+++ b/gsearch.py
@@ -45,9 +45,9 @@ class GoogleImageSearchExtention(GObject.GObject , Nautilus.MenuProvider):
         Gio.AppInfo.launch_default_for_uri(response_url)
 
     def get_file_items(self, window, files):
-        for _file in files: 
+        items = []
+        for _file in files:
             if "image/" in Gio.content_type_guess(_file.get_name())[0]:
-                items = []
                 for service in self.SERVICE_MAPPING:
                     item = Nautilus.MenuItem(
                         name="SimpleMenuExtension::Show_File_Name",
@@ -55,7 +55,7 @@ class GoogleImageSearchExtention(GObject.GObject , Nautilus.MenuProvider):
                         tip="Search %s" % _file.get_name()
                     )
                     item.connect('activate', self._upload_to_browser, _file, service)
-                    items.append(item)
+                    items = [item]
         return items
 
     def _get_file_path(self, _file):
@@ -75,4 +75,3 @@ class GoogleImageSearchExtention(GObject.GObject , Nautilus.MenuProvider):
             allow_redirects=False
         )
         return response.headers['Location']
-


### PR DESCRIPTION
I noticed that when launching nautilus from terminal output gets flooded with warnings. That happens because of two things:

1. Not initialized `GObject` throws: `RuntimeError: object at 0x7f723026e700 of type GoogleImageSearchExtention is not initialized`. According to python gtk3 documentation: `To inherit from GObject.GObject, you must call GObject.GObject.__init__() in your constructor`.
2. `UnboundLocalError: local variable 'items' referenced before assignment` happens because items are declared inside loop and return statement references `items` outside of loop's scope.

Cheers
🍷 